### PR TITLE
feat: add step to docker build into ecs pr

### DIFF
--- a/.github/workflows/ci-pull-request-ecs.yml
+++ b/.github/workflows/ci-pull-request-ecs.yml
@@ -75,3 +75,12 @@ jobs:
 
       - name: Run lint
         run: npm run lint
+
+      - name: Build, tag, and push image to Amazon ECR
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ inputs.ECR_REPOSITORY }}
+          IMAGE_TAG: ${{ inputs.GH_SHA }}
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest . --build-arg NPM_TOKEN=${NPM_TOKEN}

--- a/README.MD
+++ b/README.MD
@@ -1,0 +1,21 @@
+## About reusable workflows
+To avoid code duplication of GitHub Actions workflow files across thousands of repositories, we utilize reusable workflows. This allows us to DRY (don't repeat yourself) configurations, so we don't have to copy and paste workflows from one repository to another.
+
+## Calling reusable workflows
+In the calling workflow file, use the uses property to specify the location and version of a reusable workflow file to run as a job.
+
+```sh
+name: Sample workflow
+on:
+  pull_request:
+jobs:
+  CI:
+    uses: Lattice-Trade/membrane-github-template-actions/.github/workflows/{reusable-workflow-name}@main
+    with:
+        INPUT_1: xxx
+        INPUT_2: xxx
+    secrets:
+        SECRET_1: ${{ secrets.XXXX }}
+```
+> replace {reusable-workflow-name} to the respective reusable workflow
+


### PR DESCRIPTION
con esto solo estariamos corriendo el docker build (sin pushear la imagen) en los PR como parte del CI antes de mergear.

Una vez se mergee, ya se corre el ci-ecs.yml que no posee el `docker build`, sino el `docker build and push to ecr`

en otras palabras con esto no estariamos retrasando los tiempos del CD, unicamente al momento de realizar el PR como validacion previa