### PR TITLE
Removing ignore-scripts flag in npm ci

### DIFF
--- a/.github/workflows/typescript-install.v1.yml
+++ b/.github/workflows/typescript-install.v1.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           NODE_VERSION: ${{ inputs.NODE_VERSION }}
       - name: Install dependencies (npm ci)
-        run: npm ci --ignore-scripts
+        run: npm ci
         shell: bash
       - name: Zip and upload dependencies artifact
         uses: Lattice-Trade/membrane-github-template-actions/composite-actions/git/upload-artifact.v1@main

--- a/composite-actions/yarn/install.v1/action.yml
+++ b/composite-actions/yarn/install.v1/action.yml
@@ -12,7 +12,7 @@ runs:
       with:
         NODE_VERSION: ${{ inputs.NODE_VERSION }}
     - name: Install dependencies (yarn install)
-      run: yarn install --frozen-lockfile --ignore-scripts
+      run: yarn install --frozen-lockfile
       shell: bash
     - name: Zip and upload dependencies artifact
       uses: Lattice-Trade/membrane-github-template-actions/composite-actions/git/upload-artifact.v1@main


### PR DESCRIPTION
Some dependencies (typescript) come with building scripts inside, which run after you add or install the dependency.
Using --ignore-scripts as of now, will render many typescript dependencies useless, throwing errors when running the app or the tests.